### PR TITLE
Add more tests for BaseModel init()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *~
 # Python
 __pycache__
+# Json
+*.json


### PR DESCRIPTION
* Test positional arguments only
* Test keyword arguments only
* Test positional and keyword arguments
* Test correct and incorrect date, time format
* Test create a `BaseModel` object from a dictionary of another `BaseModel` object